### PR TITLE
[KTMS-12,13,22,23]

### DIFF
--- a/BE/Cloud/KMS.Product.Ktm.Api/Controllers/AccountController.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Controllers/AccountController.cs
@@ -18,19 +18,29 @@ namespace KMS.Product.Ktm.Api.Controllers
     [ApiController]
     public class AccountController : ControllerBase
     {
+        private const string UserInfoRequestUrl = "https://home.kms-technology.com/api/account/authenticate";
+
         public AccountController()
         {
         }
 
+        /// <summary>
+        /// api/me
+        /// Get user information by token through KMS API
+        /// </summary>
+        /// <returns>
+        /// - Status OK 200 with user information
+        /// - Status Unauthorized 401 if token expires or invalid token
+        /// </returns>
         [HttpGet("me")]
-        public async Task<IActionResult> AccountUserAsync()
+        public async Task<IActionResult> GetUserInforAsync()
         {
             try
             {
                 HttpClient client = new HttpClient();
                 var token = Request.Headers["Authorization"].ToString().Replace("Bearer ", string.Empty);
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                var response = await client.GetAsync("https://home.kms-technology.com/api/account/authenticate");
+                var response = await client.GetAsync(UserInfoRequestUrl);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {                    
                     return Ok(await response.Content.ReadAsStringAsync());

--- a/BE/Cloud/KMS.Product.Ktm.Api/Controllers/AccountController.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Controllers/AccountController.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using KMS.Product.Ktm.Api.Exceptions;
+using KMS.Product.Ktm.Entities.Models;
+using KMS.Product.Ktm.Services.EmployeeService;
+using KMS.Product.Ktm.Services.TeamService;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KMS.Product.Ktm.Api.Controllers
+{
+    [Route("api")]
+    [ApiController]
+    public class AccountController : ControllerBase
+    {
+        public AccountController()
+        {
+        }
+
+        [HttpGet("me")]
+        public async Task<IActionResult> AccountUserAsync()
+        {
+            try
+            {
+                HttpClient client = new HttpClient();
+                var token = Request.Headers["Authorization"].ToString().Replace("Bearer ", string.Empty);
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                var response = await client.GetAsync("https://home.kms-technology.com/api/account/authenticate");
+                if (response.StatusCode == HttpStatusCode.OK)
+                {                    
+                    return Ok(await response.Content.ReadAsStringAsync());
+                }
+                else
+                {
+                    return Unauthorized("Invalid token");
+                }
+            }
+            catch(BussinessException ex)
+            {
+                return StatusCode(500, $"Internal server error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/BE/Cloud/KMS.Product.Ktm.Api/Controllers/TestController.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Controllers/TestController.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using KMS.Product.Ktm.Api.Exceptions;
+using KMS.Product.Ktm.Entities.Models;
+using KMS.Product.Ktm.Services.EmployeeService;
+using KMS.Product.Ktm.Services.TeamService;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KMS.Product.Ktm.Api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class TestController : ControllerBase
+    {
+        private readonly ITeamService _teamService;
+        private readonly IEmployeeService _empService;
+        
+        public TestController(ITeamService teamService, IEmployeeService empService)
+        {
+            _teamService = teamService ?? throw new ArgumentNullException($"{nameof(teamService)}");
+            _empService = empService ?? throw new ArgumentNullException($"{nameof(empService)}");
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAllTestsAsync()
+        {
+            try
+            {
+                //await _teamService.SyncTeamDatabaseWithKmsAsync(DateTime.Now);
+                await _empService.SyncEmployeeDatabaseWithKms();
+                return Ok();
+            }
+            catch(BussinessException ex)
+            {
+                return StatusCode(500, $"Internal server error: {ex.Message}");
+            }
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateKudoTypeAsync(Employee employee)
+        {
+            try
+            {
+                await _empService.CreateEmployeeAsync(employee);
+                return Ok();
+            }
+            catch (BussinessException ex)
+            {
+                return StatusCode(500, $"Internal server error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/BE/Cloud/KMS.Product.Ktm.Api/Controllers/TestController.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Controllers/TestController.cs
@@ -11,6 +11,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace KMS.Product.Ktm.Api.Controllers
 {
+    /// <summary>
+    /// Controller used for testing with postman purpose
+    /// </summary>
     [Route("api/[controller]")]
     [ApiController]
     public class TestController : ControllerBase
@@ -30,24 +33,10 @@ namespace KMS.Product.Ktm.Api.Controllers
             try
             {
                 //await _teamService.SyncTeamDatabaseWithKmsAsync(DateTime.Now);
-                await _empService.SyncEmployeeDatabaseWithKms();
+                //await _empService.SyncEmployeeDatabaseWithKms(DateTime.Now);
                 return Ok();
             }
             catch(BussinessException ex)
-            {
-                return StatusCode(500, $"Internal server error: {ex.Message}");
-            }
-        }
-
-        [HttpPost]
-        public async Task<IActionResult> CreateKudoTypeAsync(Employee employee)
-        {
-            try
-            {
-                await _empService.CreateEmployeeAsync(employee);
-                return Ok();
-            }
-            catch (BussinessException ex)
             {
                 return StatusCode(500, $"Internal server error: {ex.Message}");
             }

--- a/BE/Cloud/KMS.Product.Ktm.Api/Job.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Job.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace KMS.Product.Ktm.Api
+{
+    public interface IJob
+    {
+        Task RunAtTimeOf(DateTime now);
+    }
+
+    //public class MyJob : IJob
+    //{
+    //    private readonly ILogger<MyJob> _logger;
+    //    private readonly MyDbContext _dbContext;
+
+    //    public 
+    //}
+}

--- a/BE/Cloud/KMS.Product.Ktm.Api/KMS.Product.Ktm.Api.csproj
+++ b/BE/Cloud/KMS.Product.Ktm.Api/KMS.Product.Ktm.Api.csproj
@@ -6,11 +6,16 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Domain\KMS.Product.Ktm.Entities\KMS.Product.Ktm.Entities.csproj" />
+    <ProjectReference Include="..\..\Domain\KMS.Product.Ktm.Services\KMS.Product.Ktm.Services.csproj" />
     <ProjectReference Include="..\..\Infrastructure\KMS.Product.Ktm.Common\KMS.Product.Ktm.Common.csproj" />
     <ProjectReference Include="..\..\Infrastructure\KMS.Product.Ktm.Repository\KMS.Product.Ktm.Repository.csproj" />
     <ProjectReference Include="..\..\Infrastructure\KMS.Product.Ktm.Utilities\KMS.Product.Ktm.Utilities.csproj" />

--- a/BE/Cloud/KMS.Product.Ktm.Api/Program.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Program.cs
@@ -26,7 +26,7 @@ namespace KMS.Product.Ktm.Api
             })
             .ConfigureServices(services =>
             {
-                services.AddHostedService<EmailHostedService>();
+                //services.AddHostedService<EmailHostedService>();
             });
     }
 }

--- a/BE/Cloud/KMS.Product.Ktm.Api/Startup.cs
+++ b/BE/Cloud/KMS.Product.Ktm.Api/Startup.cs
@@ -24,6 +24,9 @@ using KMS.Product.Ktm.Services.TeamService;
 using KMS.Product.Ktm.Services.EmployeeService;
 using KMS.Product.Ktm.Services.AutoMapper;
 using KMS.Product.Ktm.Services.AuthenticateService;
+using Hangfire;
+using Hangfire.SqlServer;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace KMS.Product.Ktm.Api
 {
@@ -40,10 +43,16 @@ namespace KMS.Product.Ktm.Api
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers(); 
+
+            //services.AddAuthentication()
+            //    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme)
+
+
+
             services.AddAuthentication("KmsTokenAuth")
                 .AddScheme<KmsTokenAuthOptions, KmsTokenAuthHandler>("KmsTokenAuth", "KmsTokenAuth", opts => { });
             services.AddSingleton<IEmailConfiguration>(Configuration.GetSection("EmailConfiguration").Get<EmailConfiguration>());
-            services.AddDbContextPool<KtmDbContext>(
+            services.AddDbContext<KtmDbContext>(
                 options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"), 
                 b => b.MigrationsAssembly("KMS.Product.Ktm.Repository")));
             services.AddScoped<IKudoTypeService, KudoTypeService>();
@@ -59,6 +68,22 @@ namespace KMS.Product.Ktm.Api
             services.AddScoped<IEmployeeRepository, EmployeeRepository>();
             services.AddScoped<ITeamRepository, TeamRepository>();
             services.AddAutoMapper(typeof(AutoMapperProfile));
+            //// Add Hangfire services.
+            //services.AddHangfire(configuration => configuration
+            //    .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
+            //    .UseSimpleAssemblyNameTypeSerializer()
+            //    .UseRecommendedSerializerSettings()
+            //    .UseSqlServerStorage(Configuration.GetConnectionString("HangfireConnection"), new SqlServerStorageOptions
+            //    {
+            //        CommandBatchMaxTimeout = TimeSpan.FromMinutes(5),
+            //        SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5),
+            //        QueuePollInterval = TimeSpan.Zero,
+            //        UseRecommendedIsolationLevel = true,
+            //        UsePageLocksOnDequeue = true,
+            //        DisableGlobalLocks = true
+            //    }));
+            //// Add the processing server as IHostedService
+            //services.AddHangfireServer();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -69,11 +94,13 @@ namespace KMS.Product.Ktm.Api
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseAuthentication();
+            //app.UseAuthentication();
 
             app.UseHttpsRedirection();
 
             app.UseRouting();
+
+            app.UseAuthentication();
 
             app.UseAuthorization();
 

--- a/BE/Cloud/KMS.Product.Ktm.Api/appsettings.json
+++ b/BE/Cloud/KMS.Product.Ktm.Api/appsettings.json
@@ -14,15 +14,18 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Hangfire": "Information"
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=KTMS;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=KTMS;Trusted_Connection=True;MultipleActiveResultSets=true",
+    "HangfireConnection": "Server=(localdb)\\mssqllocaldb;Database=KTMS-Cron;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "KmsLogin": {
     "Username": "",
     "Pasword": ""
   },
-  "KmsTestingToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9zaWQiOiIxMjg4IiwibmFtZWlkIjoiaG9hbmdodGEiLCJ1bmlxdWVfbmFtZSI6IkhvYW5nIEh1eSBUYSIsImdpdmVuX25hbWUiOiJUYSIsImZhbWlseV9uYW1lIjoiSG9hbmciLCJlbWFpbCI6ImhvYW5naHRhQGttcy10ZWNobm9sb2d5LmNvbSIsInByaW1hcnlzaWQiOiIyMDA3IiwibmJmIjoxNTg1Mjc2NTYxLCJleHAiOjE1OTMwNTI1NjEsImlhdCI6MTU4NTI3NjU2MX0.o-4YuoJ_84Fks4PcKFcJ5AzOTamRPjHjLuxPq1J0mY4"
+  "KmsTestingToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9zaWQiOiIxMzcwIiwibmFtZWlkIjoibmd1eWVueG5ndXllbiIsInVuaXF1ZV9uYW1lIjoiTmd1eWVuIFh1YW4gTmd1eWVuIiwiZ2l2ZW5fbmFtZSI6Ik5ndXllbiIsImZhbWlseV9uYW1lIjoiTmd1eWVuIiwiZW1haWwiOiJuZ3V5ZW54bmd1eWVuQGttcy10ZWNobm9sb2d5LmNvbSIsInByaW1hcnlzaWQiOiIyMDU2IiwibmJmIjoxNTg1OTI4MDUxLCJleHAiOjE1OTM3MDQwNTEsImlhdCI6MTU4NTkyODA1MX0.n4UpKWJ-Z_JKRi1ltvSQqlUOmsC-i9qnZETJVEqzhOY"
+
 }

--- a/BE/Domain/KMS.Product.Ktm.Entities/Models/Employee.cs
+++ b/BE/Domain/KMS.Product.Ktm.Entities/Models/Employee.cs
@@ -14,16 +14,16 @@ namespace KMS.Product.Ktm.Entities.Models
 
         public string Email { get; set; }
 
-        //public string SlackAccount { get; set; }
+        public string SlackAccount { get; set; }
 
         public DateTime JoinedDate { get; set; }
 
-        public int EmployeeRoleId {get; set;}
+        public int? EmployeeRoleId {get; set;}
 
         public string CurrentTeam { get; set; }
 
         public virtual EmployeeRole EmployeeRole { get; set; }
 
-        public virtual ICollection<EmployeeTeam> EmployeeTeams { get; set; }
+        public virtual List<EmployeeTeam> EmployeeTeams { get; set; } = new List<EmployeeTeam>();
     }
 }

--- a/BE/Domain/KMS.Product.Ktm.Services/EmployeeService/EmployeeService.cs
+++ b/BE/Domain/KMS.Product.Ktm.Services/EmployeeService/EmployeeService.cs
@@ -110,6 +110,15 @@ namespace KMS.Product.Ktm.Services.EmployeeService
             await SyncNewEmployees(newEmployees);
             // Sync active employees 
             var activeEmployees = fetchedEmployees.Where(e => databaseEmployeeBadgeIds.Contains(e.EmployeeBadgeId));
+            Dictionary<string, int> map = databaseEmployees.ToDictionary(x => x.EmployeeBadgeId, x => x.Id);
+            foreach (var item in activeEmployees)
+            {
+                if (map.ContainsKey(item.EmployeeBadgeId))
+                {
+                    item.Id = map[item.EmployeeBadgeId];
+                }
+            }
+            activeEmployees.ToList().ForEach()
             await SyncActiveEmployees(activeEmployees);
             // Sync quit employees
             var quitEmployees = databaseEmployees.Where(e => !fetchedEmployeeBadgeIds.Contains(e.EmployeeBadgeId));
@@ -167,7 +176,7 @@ namespace KMS.Product.Ktm.Services.EmployeeService
             {
                 var currentTeam = newEmployee.CurrentTeam;
                 var currentTeamId = await _teamService.GetTeamIdByTeamNameAsync(currentTeam);
-                newEmployee.EmployeeTeams.Add(new EmployeeTeam()
+                newEmployee.EmployeeTeams.Add(new EmployeeTeam()           
                 {
                     TeamID = currentTeamId,
                     JoinedDate = DateTime.Now,

--- a/BE/Domain/KMS.Product.Ktm.Services/EmployeeService/IEmployeeService.cs
+++ b/BE/Domain/KMS.Product.Ktm.Services/EmployeeService/IEmployeeService.cs
@@ -50,6 +50,6 @@ namespace KMS.Product.Ktm.Services.EmployeeService
         ///     Update release date of the current team to now
         /// </summary>
         /// <returns></returns>
-        Task SyncEmployeeDatabaseWithKms();
+        Task SyncEmployeeDatabaseWithKms(DateTime now);
     }
 }

--- a/BE/Domain/KMS.Product.Ktm.Services/Hangfire/HangfireJobScheduler.cs
+++ b/BE/Domain/KMS.Product.Ktm.Services/Hangfire/HangfireJobScheduler.cs
@@ -1,0 +1,23 @@
+﻿using Hangfire;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KMS.Product.Ktm.Services.Hangfire
+{
+    public static class HangfireJobScheduler 
+    {
+        public static void ScheduleRecurringJob()
+        {
+            RecurringJob.RemoveIfExists(nameof(TeamService.TeamService));
+            RecurringJob.AddOrUpdate<TeamService.TeamService>(nameof(TeamService),
+                job => job.Run(JobCancellationToken.Null),
+                Cron.MinuteInterval(1), TimeZoneInfo.Local);
+
+            //RecurringJob.RemoveIfExists(nameof(EmployeeService.EmployeeService));
+            //RecurringJob.AddOrUpdate<EmployeeService.EmployeeService>(nameof(EmployeeService),
+            //    job => job.Run(JobCancellationToken.Null),
+            //    Cron.MinuteInterval(1), TimeZoneInfo.Local);
+        }
+    }
+}

--- a/BE/Domain/KMS.Product.Ktm.Services/Hangfire/HangfireJobScheduler.cs
+++ b/BE/Domain/KMS.Product.Ktm.Services/Hangfire/HangfireJobScheduler.cs
@@ -7,17 +7,20 @@ namespace KMS.Product.Ktm.Services.Hangfire
 {
     public static class HangfireJobScheduler 
     {
+        private const int TeamServiceInterval = 1;
+        private const int EmployeeServiceInterval = 1;
+
         public static void ScheduleRecurringJob()
         {
             RecurringJob.RemoveIfExists(nameof(TeamService.TeamService));
             RecurringJob.AddOrUpdate<TeamService.TeamService>(nameof(TeamService),
                 job => job.Run(JobCancellationToken.Null),
-                Cron.MinuteInterval(1), TimeZoneInfo.Local);
+                Cron.MinuteInterval(TeamServiceInterval), TimeZoneInfo.Local);
 
-            //RecurringJob.RemoveIfExists(nameof(EmployeeService.EmployeeService));
-            //RecurringJob.AddOrUpdate<EmployeeService.EmployeeService>(nameof(EmployeeService),
-            //    job => job.Run(JobCancellationToken.Null),
-            //    Cron.MinuteInterval(1), TimeZoneInfo.Local);
+            RecurringJob.RemoveIfExists(nameof(EmployeeService.EmployeeService));
+            RecurringJob.AddOrUpdate<EmployeeService.EmployeeService>(nameof(EmployeeService),
+                job => job.Run(JobCancellationToken.Null),
+                Cron.MinuteInterval(EmployeeServiceInterval), TimeZoneInfo.Local);
         }
     }
 }

--- a/BE/Domain/KMS.Product.Ktm.Services/KMS.Product.Ktm.Services.csproj
+++ b/BE/Domain/KMS.Product.Ktm.Services/KMS.Product.Ktm.Services.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="Hangfire" Version="1.7.10" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.10" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.10" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.7.10" />
     <PackageReference Include="Mailkit" Version="2.5.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
   </ItemGroup>

--- a/BE/Domain/KMS.Product.Ktm.Services/TeamService/ITeamService.cs
+++ b/BE/Domain/KMS.Product.Ktm.Services/TeamService/ITeamService.cs
@@ -56,6 +56,6 @@ namespace KMS.Product.Ktm.Services.TeamService
         /// 3. Disband teams
         /// </summary>
         /// <returns></returns>
-        Task SyncTeamDatabaseWithKmsAsync();
+        Task SyncTeamDatabaseWithKmsAsync(DateTime now);
     }
 }

--- a/BE/Domain/KMS.Product.Ktm.Services/TeamService/TeamService.cs
+++ b/BE/Domain/KMS.Product.Ktm.Services/TeamService/TeamService.cs
@@ -147,9 +147,13 @@ namespace KMS.Product.Ktm.Services.TeamService
             // Sync disband teams
             var disbandTeams = databaseTeams.Where(e => !fetchedTeamNames.Contains(e.TeamName));
             await SyncDisbandTeams(disbandTeams);
-            _logger.LogInformation("End sync team");
         }
 
+        /// <summary>
+        /// Used for Hangfire scheduler
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
         public async Task Run(IJobCancellationToken token)
         {
             token.ThrowIfCancellationRequested();

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/BaseRepository.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/BaseRepository.cs
@@ -94,11 +94,8 @@ namespace KMS.Product.Ktm.Repository
                 throw new ArgumentNullException("entity");
             }
             entity.Modified = DateTime.Now;
-            //_logger.LogInformation($"{context.Entry(entity).State}");
-            //context.Entry(entity).State = EntityState.Detached;
             context.Entry(entity).Property(e => e.Created).IsModified = false;
             entities.Update(entity);
-            //context.Entry(entity).State = EntityState.Modified;
             if (saveChange)
                 await context.SaveChangesAsync();
         }

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/EmployeeRepository.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/EmployeeRepository.cs
@@ -1,5 +1,7 @@
 ﻿using KMS.Product.Ktm.Entities.Models;
 using KMS.Product.Ktm.Services.RepoInterfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +12,7 @@ namespace KMS.Product.Ktm.Repository
 {
     public class EmployeeRepository : BaseRepository<Employee>, IEmployeeRepository
     {
-        public EmployeeRepository(KtmDbContext context) : base(context)
+        public EmployeeRepository(KtmDbContext context, ILogger<Employee> logger) : base(context, logger)
         {
         }
 
@@ -20,7 +22,7 @@ namespace KMS.Product.Ktm.Repository
         /// <returns>A collection of all employees</returns>
         public async Task<IEnumerable<Employee>> GetEmployeesAsync()
         {
-            return await Task.FromResult(GetAll().ToList());
+            return await Task.FromResult(GetAll().Include(e => e.EmployeeTeams).ToList());
         }
     }
 }

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/KMS.Product.Ktm.Repository.csproj
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/KMS.Product.Ktm.Repository.csproj
@@ -5,11 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0-preview.2.20120.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0-preview.2.20120.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0-preview.2.20120.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-preview.2.20120.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0-preview.2.20120.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
 
   </ItemGroup>
 

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/KtmDBContext.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/KtmDBContext.cs
@@ -22,6 +22,11 @@ namespace KMS.Product.Ktm.Repository
         public DbSet<Kudo> Kudos { get; set; }
         public DbSet<KudoDetail> KudoDetails { get; set; }
 
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseLazyLoadingProxies();
+        }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             foreach (var property in modelBuilder.Model.GetEntityTypes()

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/KudoRepository.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/KudoRepository.cs
@@ -3,12 +3,13 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using KMS.Product.Ktm.Entities.Models;
 using KMS.Product.Ktm.Services.RepoInterfaces;
+using Microsoft.Extensions.Logging;
 
 namespace KMS.Product.Ktm.Repository
 {
     public class KudoRepository : BaseRepository<Kudo>, IKudoRepository
     {
-        public KudoRepository(KtmDbContext context) : base(context)
+        public KudoRepository(KtmDbContext context, ILogger<Kudo> logger) : base(context, logger)
         {
         }
 

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/KudoTypeRepository.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/KudoTypeRepository.cs
@@ -1,5 +1,6 @@
 ﻿using KMS.Product.Ktm.Entities.Models;
 using KMS.Product.Ktm.Services.RepoInterfaces;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +11,7 @@ namespace KMS.Product.Ktm.Repository
 {
     public class KudoTypeRepository : BaseRepository<KudoType>, IKudoTypeRepository
     {
-        public KudoTypeRepository(KtmDbContext context) : base(context)
+        public KudoTypeRepository(KtmDbContext context, ILogger<KudoType> logger) : base(context, logger)
         {
         }
 

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/Migrations/20200405230801_Initial.Designer.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/Migrations/20200405230801_Initial.Designer.cs
@@ -4,14 +4,16 @@ using KMS.Product.Ktm.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace KMS.Product.Ktm.Repository.Migrations
 {
     [DbContext(typeof(KtmDbContext))]
-    partial class KtmDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200405230801_Initial")]
+    partial class Initial
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/Migrations/20200405230801_Initial.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/Migrations/20200405230801_Initial.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace KMS.Product.Ktm.Repository.Migrations
+{
+    public partial class Initial : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmployeeRoles",
+                columns: table => new
+                {
+                    EmployeeRoleId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    RoleName = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmployeeRoles", x => x.EmployeeRoleId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "KudoTypes",
+                columns: table => new
+                {
+                    KudoTypeId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    TypeName = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KudoTypes", x => x.KudoTypeId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Teams",
+                columns: table => new
+                {
+                    TeamId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    TeamName = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Teams", x => x.TeamId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Employees",
+                columns: table => new
+                {
+                    EmployeeId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    EmployeeBadgeId = table.Column<string>(nullable: true),
+                    LastName = table.Column<string>(nullable: true),
+                    FirstMidName = table.Column<string>(nullable: true),
+                    Email = table.Column<string>(nullable: true),
+                    SlackAccount = table.Column<string>(nullable: true),
+                    JoinedDate = table.Column<DateTime>(nullable: false),
+                    EmployeeRoleId = table.Column<int>(nullable: true),
+                    CurrentTeam = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Employees", x => x.EmployeeId);
+                    table.ForeignKey(
+                        name: "FK_Employees_EmployeeRoles_EmployeeRoleId",
+                        column: x => x.EmployeeRoleId,
+                        principalTable: "EmployeeRoles",
+                        principalColumn: "EmployeeRoleId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "KudoDetails",
+                columns: table => new
+                {
+                    KudoDetailId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    Content = table.Column<string>(nullable: true),
+                    KudoTypeId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_KudoDetails", x => x.KudoDetailId);
+                    table.ForeignKey(
+                        name: "FK_KudoDetails_KudoTypes_KudoTypeId",
+                        column: x => x.KudoTypeId,
+                        principalTable: "KudoTypes",
+                        principalColumn: "KudoTypeId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EmployeeTeams",
+                columns: table => new
+                {
+                    EmployeeTeamId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    JoinedDate = table.Column<DateTime>(nullable: false),
+                    ReleseadDate = table.Column<DateTime>(nullable: true),
+                    EmployeeID = table.Column<int>(nullable: false),
+                    TeamID = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmployeeTeams", x => x.EmployeeTeamId);
+                    table.ForeignKey(
+                        name: "FK_EmployeeTeams_Employees_EmployeeID",
+                        column: x => x.EmployeeID,
+                        principalTable: "Employees",
+                        principalColumn: "EmployeeId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_EmployeeTeams_Teams_TeamID",
+                        column: x => x.TeamID,
+                        principalTable: "Teams",
+                        principalColumn: "TeamId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Kudos",
+                columns: table => new
+                {
+                    KudoId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Modified = table.Column<DateTime>(nullable: false),
+                    SenderId = table.Column<int>(nullable: false),
+                    ReceiverId = table.Column<int>(nullable: false),
+                    KudoDetailId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Kudos", x => x.KudoId);
+                    table.ForeignKey(
+                        name: "FK_Kudos_KudoDetails_KudoDetailId",
+                        column: x => x.KudoDetailId,
+                        principalTable: "KudoDetails",
+                        principalColumn: "KudoDetailId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Kudos_EmployeeTeams_ReceiverId",
+                        column: x => x.ReceiverId,
+                        principalTable: "EmployeeTeams",
+                        principalColumn: "EmployeeTeamId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Kudos_EmployeeTeams_SenderId",
+                        column: x => x.SenderId,
+                        principalTable: "EmployeeTeams",
+                        principalColumn: "EmployeeTeamId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_EmployeeRoleId",
+                table: "Employees",
+                column: "EmployeeRoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmployeeTeams_EmployeeID",
+                table: "EmployeeTeams",
+                column: "EmployeeID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmployeeTeams_TeamID",
+                table: "EmployeeTeams",
+                column: "TeamID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KudoDetails_KudoTypeId",
+                table: "KudoDetails",
+                column: "KudoTypeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Kudos_KudoDetailId",
+                table: "Kudos",
+                column: "KudoDetailId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Kudos_ReceiverId",
+                table: "Kudos",
+                column: "ReceiverId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Kudos_SenderId",
+                table: "Kudos",
+                column: "SenderId",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Kudos");
+
+            migrationBuilder.DropTable(
+                name: "KudoDetails");
+
+            migrationBuilder.DropTable(
+                name: "EmployeeTeams");
+
+            migrationBuilder.DropTable(
+                name: "KudoTypes");
+
+            migrationBuilder.DropTable(
+                name: "Employees");
+
+            migrationBuilder.DropTable(
+                name: "Teams");
+
+            migrationBuilder.DropTable(
+                name: "EmployeeRoles");
+        }
+    }
+}

--- a/BE/Infrastructure/KMS.Product.Ktm.Repository/TeamRepository.cs
+++ b/BE/Infrastructure/KMS.Product.Ktm.Repository/TeamRepository.cs
@@ -1,5 +1,6 @@
 ﻿using KMS.Product.Ktm.Entities.Models;
 using KMS.Product.Ktm.Services.RepoInterfaces;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,7 @@ namespace KMS.Product.Ktm.Repository
 {
     public class TeamRepository : BaseRepository<Team>, ITeamRepository
     {
-        public TeamRepository(KtmDbContext context) : base(context)
+        public TeamRepository(KtmDbContext context, ILogger<Team> logger) : base(context, logger)
         {
         }
 

--- a/BE/KMS.Product.Ktm.EntitiesServices/DTOs/KmsTeamDTO.cs
+++ b/BE/KMS.Product.Ktm.EntitiesServices/DTOs/KmsTeamDTO.cs
@@ -11,6 +11,6 @@ namespace KMS.Product.Ktm.EntitiesServices.DTOs
         /// Map ClientName in JSON response to TeamName when deserializing
         /// </summary>
         [JsonProperty("ClientName")]
-       public string TeamName { get; set; }    
+        public string TeamName { get; set; }    
     }
 }

--- a/BE/KMS.Product.Ktm.EntitiesServices/Responses/KmsTeamResponse.cs
+++ b/BE/KMS.Product.Ktm.EntitiesServices/Responses/KmsTeamResponse.cs
@@ -1,4 +1,5 @@
 ﻿using KMS.Product.Ktm.EntitiesServices.DTOs;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -7,6 +8,7 @@ namespace KMS.Product.Ktm.EntitiesServices.Responses
 {
     public class KmsTeamResponse
     {
+        [JsonProperty("")]
         public IEnumerable<KmsTeamDTO> KmsTeamDTOs { get; set; }
     }
 }


### PR DESCRIPTION
- Finalize EmployeeService, TeamService
- Using EmployeeService, TeamService with HangfireJobScheduler
- Using in-memory cache for token checking in KmsTokenAuthHandler
- Remove AutoMapper package from KMS.Product.Ktm.Api
- Downgrade EF Core packages to version 3.1.3 for the purpose of using EF Core Proxy for lazy loading
- Currently lazy loading using proxy is declared but has not been used yet since it does not work with AsNoTracking entites when querying